### PR TITLE
Update the Swift package to swift tools 4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,13 @@
+// swift-tools-version:4.2
+
 import PackageDescription
 
 let package = Package(
-    name: "SwiftTryCatch"
+    name: "SwiftTryCatch",
+    products: [
+        .library(name: "SwiftTryCatch", targets: ["SwiftTryCatch"]),
+    ],
+    targets: [
+        .target(name: "SwiftTryCatch", dependencies: [], path: "Sources", sources: ["SwiftTryCatch.m", "include/SwiftTryCatch.h"]),
+    ]
 )


### PR DESCRIPTION
I don't have a way of verifying this *works* per-say other than `swift build` is happy and the import is referenced inside the module map.